### PR TITLE
@86eqxm05v #Revamped cookie consent dialog and adjusted scroll to top icon

### DIFF
--- a/apps/web-customer/src/components/blocks/AboutUsBlock/AboutUsBlock.tsx
+++ b/apps/web-customer/src/components/blocks/AboutUsBlock/AboutUsBlock.tsx
@@ -1,19 +1,21 @@
-import React from 'react'
+import React from "react";
 import {
   AboutUsHeroBlock,
   OurHistoryBlock,
   MeetOurTeamBlock,
   FAQBlock,
 } from "./index";
-import { Stack } from '@mui/material';
+import { Stack } from "@mui/material";
+import { ScrollTop } from "core-library/components";
 
 export const AboutUsBlock = () => {
   return (
     <Stack>
-      <AboutUsHeroBlock/>
-      <OurHistoryBlock/>
-      <FAQBlock/>
-      <MeetOurTeamBlock/>
+      <AboutUsHeroBlock />
+      <OurHistoryBlock />
+      <FAQBlock />
+      <MeetOurTeamBlock />
+      <ScrollTop />
     </Stack>
-  )
-}
+  );
+};

--- a/apps/web-customer/src/pages/contact.tsx
+++ b/apps/web-customer/src/pages/contact.tsx
@@ -2,12 +2,14 @@ import { ContactFormBlock } from "../components/blocks/ContactBlock/ContactFormB
 import { ContactHero } from "../components/blocks/ContactBlock/ContactHero";
 import { GetServerSideProps } from "next";
 import { withCSP } from "core-library";
+import { ScrollTop } from "core-library/components";
 
 const ContactPage: React.FC = () => {
   return (
     <div>
       <ContactHero />
       <ContactFormBlock />
+      <ScrollTop />
     </div>
   );
 };

--- a/apps/web-customer/src/pages/index.tsx
+++ b/apps/web-customer/src/pages/index.tsx
@@ -12,14 +12,15 @@ import useWebHeaderStyles from "@/pages/contents/useWebHeaderStyles";
 import { IconButton } from "@mui/material";
 import { SsrTypes } from "core-library/types/global";
 import { useEndpointByKey } from "core-library/hooks";
+import { ScrollTop } from "core-library/components";
 
 interface Props {
   data?: SsrTypes;
 }
 
 const Home: React.FC<Props> = ({ data }) => {
-  const { scrollTop } = useScroll();
-  const { ToTopButtonSx } = useWebHeaderStyles();
+  // const { scrollTop } = useScroll();
+  // const { ToTopButtonSx } = useWebHeaderStyles();
 
   const url = useEndpointByKey({
     data: data?.endpoints,
@@ -29,19 +30,6 @@ const Home: React.FC<Props> = ({ data }) => {
   return (
     <React.Fragment>
       <div className="w-screen flex flex-col overflow-y-auto overflow-x-hidden font-ptSans ">
-        <IconButton
-          onClick={() => scrollTop()}
-          sx={ToTopButtonSx}
-          className="fadeIn"
-        >
-          <NorthIcon
-            sx={{
-              width: "25px",
-              height: "25px",
-            }}
-            className="text-[#0f2a71]"
-          />
-        </IconButton>
         <div className="w-full h-screen">
           <RevolutionBannerBlock />
         </div>
@@ -55,6 +43,7 @@ const Home: React.FC<Props> = ({ data }) => {
           <PricingBlock url={url} />
         </div>
       </div>
+      <ScrollTop />
     </React.Fragment>
   );
 };

--- a/apps/web-customer/src/pages/index.tsx
+++ b/apps/web-customer/src/pages/index.tsx
@@ -4,12 +4,9 @@ import {
   HowItWorksBlock,
   PricingBlock,
 } from "@/components";
-import { useScroll, withCSP } from "core-library";
+import { withCSP } from "core-library";
 import { GetServerSideProps } from "next";
-import NorthIcon from "@mui/icons-material/North";
 import React from "react";
-import useWebHeaderStyles from "@/pages/contents/useWebHeaderStyles";
-import { IconButton } from "@mui/material";
 import { SsrTypes } from "core-library/types/global";
 import { useEndpointByKey } from "core-library/hooks";
 import { ScrollTop } from "core-library/components";
@@ -19,9 +16,6 @@ interface Props {
 }
 
 const Home: React.FC<Props> = ({ data }) => {
-  // const { scrollTop } = useScroll();
-  // const { ToTopButtonSx } = useWebHeaderStyles();
-
   const url = useEndpointByKey({
     data: data?.endpoints,
     key: "pricing-section",

--- a/apps/web-customer/src/pages/shared/Layout.tsx
+++ b/apps/web-customer/src/pages/shared/Layout.tsx
@@ -18,12 +18,22 @@ import {
   CustomerMenus,
   list,
 } from "core-library/core/utils/contants/wc/HomePageData";
-import { ChatBotWidget, DrawerLayout, MultiContentDialog } from "core-library/components";
-import { useWebHeaderStyles } from "@/pages/contents/useWebHeaderStyles";
-import { useConfirmedIntent, useNewAccount } from "core-library/contexts/auth/hooks";
+import {
+  ChatBotWidget,
+  DrawerLayout,
+  MultiContentDialog,
+} from "core-library/components";
+import {
+  useConfirmedIntent,
+  useNewAccount,
+} from "core-library/contexts/auth/hooks";
 import { usePaymentSuccessRedirect } from "@/core/hooks/usePaymentSuccessRedirect";
 import { theme } from "core-library/contents/theme/theme";
-import { useAuthInterceptor, useStyle } from "core-library/hooks";
+import {
+  useAuthInterceptor,
+  useStyle,
+  useWebHeaderStyles,
+} from "core-library/hooks";
 import { PageLoaderContextProvider } from "core-library/contexts/PageLoaderContext";
 import { useContentDataContext } from "core-library/contexts/content/ContentDataContext";
 import { ContentLoader } from "core-library/router";
@@ -46,7 +56,14 @@ const Layout: React.FC<React.PropsWithChildren<{}>> = ({ children }) => {
   const showWelcomeDialog = isAuthenticated && isNewAccount;
 
   if (showWelcomeDialog) {
-    return <MultiContentDialog content={dataContent} open={showWelcomeDialog} handleClose={() => { }} showTour />
+    return (
+      <MultiContentDialog
+        content={dataContent}
+        open={showWelcomeDialog}
+        handleClose={() => {}}
+        showTour
+      />
+    );
   }
 
   return (

--- a/packages/core-library/components/Button/IconButton.tsx
+++ b/packages/core-library/components/Button/IconButton.tsx
@@ -4,7 +4,7 @@
  * Created by the Software Strategy & Development Division
  */
 import * as React from "react";
-import { IconButton as MuiIconButton } from "@mui/material";
+import { IconButton as MuiIconButton, SxProps } from "@mui/material";
 
 interface Props {
   size?: "small" | "medium" | "large";
@@ -12,7 +12,8 @@ interface Props {
   onClick: (event?: React.MouseEvent<HTMLButtonElement>) => void;
   edge?: false | "start" | "end";
   className?: string;
-};
+  sx?: SxProps;
+}
 
 export const IconButton: React.FC<React.PropsWithChildren<Props>> = ({
   size,
@@ -20,10 +21,18 @@ export const IconButton: React.FC<React.PropsWithChildren<Props>> = ({
   onClick,
   edge,
   children,
-  className
+  className,
+  sx,
 }) => {
   return (
-    <MuiIconButton aria-label={ariaLabel} size={size} onClick={onClick} edge={edge} className={className} sx={{ "&:focus": { outline: "none !important" } }}>
+    <MuiIconButton
+      aria-label={ariaLabel}
+      size={size}
+      onClick={onClick}
+      edge={edge}
+      className={className}
+      sx={{ "&:focus": { outline: "none !important" }, ...sx }}
+    >
       {children}
     </MuiIconButton>
   );

--- a/packages/core-library/components/Dialog/CookieConsentDialog.tsx
+++ b/packages/core-library/components/Dialog/CookieConsentDialog.tsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useState } from "react";
-import { Button, Box, SxProps } from "@mui/material";
+import { Box, SxProps } from "@mui/material";
+import { Button } from "../Button/Button";
 import { useResolution } from "../../hooks";
 import { useRouter, useScroll } from "../../core";
 import { useCookie } from "../../hooks/useCookie";
+import { ScrollTop } from "../ScrollTop/ScrollTop";
 
 const COOKIE_NAME = "user_cookie_consent";
 
@@ -11,8 +13,9 @@ const buttonSx: SxProps = {
   fontFamily: "PT Sans, sans-serif",
   fontSize: "1rem",
   minHeight: "unset",
+  minWidth: "120px",
   height: "2.5rem",
-  padding: "0 16px",
+  padding: "0",
   borderRadius: "15px",
   textWrap: "nowrap",
 };
@@ -64,9 +67,11 @@ export const CookieConsentDialog: React.FC = () => {
             flexDirection: "column",
           }}
         >
+          <ScrollTop forCookieConsent />
           <Box
             sx={{
               bgcolor: !isScrolledOrRoute ? "white" : "rgba(0, 0, 0, 0.9)",
+              backdropFilter: "blur(3px)",
               color: isScrolledOrRoute ? "white" : "black",
               padding: "1rem 2rem",
               minHeight: "100px",

--- a/packages/core-library/components/Dialog/CookieConsentDialog.tsx
+++ b/packages/core-library/components/Dialog/CookieConsentDialog.tsx
@@ -6,16 +6,35 @@ import {
   DialogContentText,
   DialogTitle,
   Button,
+  Box,
+  SxProps,
 } from "@mui/material";
+import { useResolution } from "../../hooks";
+import { useRouter, useScroll } from "../../core";
 import { useCookie } from "../../hooks/useCookie";
 
 const COOKIE_NAME = "user_cookie_consent";
 
+const buttonSx: SxProps = {
+  fontWeight: 600,
+  fontFamily: "PT Sans, sans-serif",
+  fontSize: "1rem",
+  minHeight: "unset",
+  height: "2.5rem",
+  padding: "0 16px",
+  borderRadius: "15px",
+  textWrap: "nowrap",
+};
+
 export const CookieConsentDialog: React.FC = () => {
-  const [cookieConsent, setCookieConsent, clearCookieConsent] = useCookie<
-    string | null
-  >(COOKIE_NAME);
+  const [cookieConsent, setCookieConsent] = useCookie<string | null>(
+    COOKIE_NAME
+  );
   const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const { isScrolled } = useScroll();
+  const { isMobile } = useResolution();
+  const router = useRouter();
+  const isScrolledOrRoute = router.pathname === "/404" || isScrolled;
 
   useEffect(() => {
     if (!cookieConsent) {
@@ -42,31 +61,150 @@ export const CookieConsentDialog: React.FC = () => {
   };
 
   return (
-    <Dialog open={isDialogOpen} onClose={handleDeclineCookie}>
-      <DialogTitle>Cookies Consent</DialogTitle>
-      <DialogContent>
-        <DialogContentText>
-          We use cookies to enhance your experience, analyze site traffic, and
-          serve personalized content. By accepting, you consent to our cookie
-          policy. You can decline if you prefer limited functionality.
-        </DialogContentText>
-      </DialogContent>
-      <DialogActions>
-        <Button
-          variant="outlined"
-          color="secondary"
-          onClick={handleDeclineCookie}
+    <>
+      {isDialogOpen && (
+        <Box
+          sx={{
+            position: "fixed",
+            width: "100%",
+            bottom: "0px",
+            zIndex: "9999999",
+            display: "flex",
+            flexDirection: "column",
+          }}
         >
-          Decline
-        </Button>
-        <Button
-          variant="contained"
-          color="primary"
-          onClick={handleAcceptCookie}
-        >
-          Accept
-        </Button>
-      </DialogActions>
-    </Dialog>
+          <Box
+            sx={{
+              bgcolor: !isScrolledOrRoute ? "white" : "rgba(0, 0, 0, 0.9)",
+              color: isScrolledOrRoute ? "white" : "black",
+              padding: "1rem 2rem",
+              minHeight: "100px",
+            }}
+          >
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: isMobile ? "column" : "row",
+                justifyContent: "center",
+                alignItems: isMobile ? "end" : "center",
+                gap: "1rem",
+              }}
+            >
+              <div>
+                <span className="font-bold">We Value Your Privacy</span>
+                <p
+                  className="text-sm"
+                  style={{ margin: "0", marginTop: "10px" }}
+                >
+                  We use cookies to enhance your experience, analyze site
+                  traffic, and serve personalized content. By accepting, you
+                  consent to our cookie policy. You can decline if you prefer
+                  limited functionality.
+                </p>
+              </div>
+              <Box
+                sx={{
+                  display: "flex",
+                  justifyContent: "end",
+                  gap: "10px",
+                }}
+              >
+                <Button
+                  variant="outlined"
+                  sx={{
+                    ...buttonSx,
+                    color: isScrolledOrRoute ? "white" : "black",
+                    borderColor: isScrolledOrRoute ? "white" : "black",
+                  }}
+                  onClick={handleDeclineCookie}
+                >
+                  Decline
+                </Button>
+                <Button
+                  variant="contained"
+                  sx={{
+                    ...buttonSx,
+                    color: !isScrolledOrRoute ? "white" : "black",
+                    bgcolor: !isScrolledOrRoute ? "#0f2a71" : "#f3c402",
+                    "&:hover": {
+                      backgroundColor: !isScrolledOrRoute
+                        ? "#071c51"
+                        : "#cca406",
+                    },
+                    ":disabled": {
+                      color: !isScrolledOrRoute ? "#071c51" : "#cca406",
+                      textDecoration: "underline",
+                    },
+                  }}
+                  onClick={handleAcceptCookie}
+                >
+                  Accept All
+                </Button>
+              </Box>
+            </Box>
+          </Box>
+        </Box>
+      )}
+    </>
   );
 };
+
+// export const CookieConsentDialog: React.FC = () => {
+//   const [cookieConsent, setCookieConsent, clearCookieConsent] = useCookie<
+//     string | null
+//   >(COOKIE_NAME);
+//   const [isDialogOpen, setIsDialogOpen] = useState(false);
+
+//   useEffect(() => {
+//     if (!cookieConsent) {
+//       setIsDialogOpen(true);
+//     }
+//   }, [cookieConsent]);
+
+//   const handleAcceptCookie = () => {
+//     setCookieConsent("accepted", {
+//       path: "/",
+//       expires: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+//     });
+//     setIsDialogOpen(false);
+//   };
+
+//   const handleDeclineCookie = () => {
+//     setCookieConsent("declined", {
+//       path: "/",
+//       expires: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+//     });
+//     setIsDialogOpen(false);
+//     //decide either we should direct user to an error page or not.
+//     //if user can still proceed with the application then do not initialize tracking scripts or analytics.
+//   };
+
+//   return (
+//     <Dialog open={isDialogOpen} onClose={handleDeclineCookie}>
+//       <DialogTitle>Cookies Consent</DialogTitle>
+//       <DialogContent>
+//         <DialogContentText>
+//           We use cookies to enhance your experience, analyze site traffic, and
+//           serve personalized content. By accepting, you consent to our cookie
+//           policy. You can decline if you prefer limited functionality.
+//         </DialogContentText>
+//       </DialogContent>
+//       <DialogActions>
+//         <Button
+//           variant="outlined"
+//           color="secondary"
+//           onClick={handleDeclineCookie}
+//         >
+//           Decline
+//         </Button>
+//         <Button
+//           variant="contained"
+//           color="primary"
+//           onClick={handleAcceptCookie}
+//         >
+//           Accept
+//         </Button>
+//       </DialogActions>
+//     </Dialog>
+//   );
+// };

--- a/packages/core-library/components/Dialog/CookieConsentDialog.tsx
+++ b/packages/core-library/components/Dialog/CookieConsentDialog.tsx
@@ -1,14 +1,5 @@
 import React, { useEffect, useState } from "react";
-import {
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogContentText,
-  DialogTitle,
-  Button,
-  Box,
-  SxProps,
-} from "@mui/material";
+import { Button, Box, SxProps } from "@mui/material";
 import { useResolution } from "../../hooks";
 import { useRouter, useScroll } from "../../core";
 import { useCookie } from "../../hooks/useCookie";
@@ -148,63 +139,3 @@ export const CookieConsentDialog: React.FC = () => {
     </>
   );
 };
-
-// export const CookieConsentDialog: React.FC = () => {
-//   const [cookieConsent, setCookieConsent, clearCookieConsent] = useCookie<
-//     string | null
-//   >(COOKIE_NAME);
-//   const [isDialogOpen, setIsDialogOpen] = useState(false);
-
-//   useEffect(() => {
-//     if (!cookieConsent) {
-//       setIsDialogOpen(true);
-//     }
-//   }, [cookieConsent]);
-
-//   const handleAcceptCookie = () => {
-//     setCookieConsent("accepted", {
-//       path: "/",
-//       expires: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
-//     });
-//     setIsDialogOpen(false);
-//   };
-
-//   const handleDeclineCookie = () => {
-//     setCookieConsent("declined", {
-//       path: "/",
-//       expires: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
-//     });
-//     setIsDialogOpen(false);
-//     //decide either we should direct user to an error page or not.
-//     //if user can still proceed with the application then do not initialize tracking scripts or analytics.
-//   };
-
-//   return (
-//     <Dialog open={isDialogOpen} onClose={handleDeclineCookie}>
-//       <DialogTitle>Cookies Consent</DialogTitle>
-//       <DialogContent>
-//         <DialogContentText>
-//           We use cookies to enhance your experience, analyze site traffic, and
-//           serve personalized content. By accepting, you consent to our cookie
-//           policy. You can decline if you prefer limited functionality.
-//         </DialogContentText>
-//       </DialogContent>
-//       <DialogActions>
-//         <Button
-//           variant="outlined"
-//           color="secondary"
-//           onClick={handleDeclineCookie}
-//         >
-//           Decline
-//         </Button>
-//         <Button
-//           variant="contained"
-//           color="primary"
-//           onClick={handleAcceptCookie}
-//         >
-//           Accept
-//         </Button>
-//       </DialogActions>
-//     </Dialog>
-//   );
-// };

--- a/packages/core-library/components/ScrollTop/ScrollTop.tsx
+++ b/packages/core-library/components/ScrollTop/ScrollTop.tsx
@@ -1,46 +1,39 @@
 import { useScroll } from "../../core";
-import NorthIcon from "@mui/icons-material/North";
-import { IconButton, SxProps } from "@mui/material";
+import { IconButton } from "../Button/IconButton";
 import { useCookie } from "../../hooks/useCookie";
+import { useWebHeaderStyles } from "../../hooks";
+import { EvaIcon } from "../EvaIcon";
+
+interface ScrollTopProps {
+  forCookieConsent?: boolean;
+}
 
 const COOKIE_NAME = "user_cookie_consent";
 
-export const ScrollTop = () => {
-  const { scrollTop, isScrolled } = useScroll();
+export const ScrollTop: React.FC<ScrollTopProps> = ({
+  forCookieConsent = false,
+}) => {
+  const { scrollTop } = useScroll();
   const [cookieConsent] = useCookie<string | null>(COOKIE_NAME);
-
-  const ToTopButtonSx: SxProps = {
-    position: "fixed",
-    zIndex: 10000,
-    bottom: cookieConsent ? "50px" : "120px",
-    right: "50px",
-    height: "45px",
-    width: "45px",
-    boxShadow: "2px",
-    minWidth: "40px",
-    bgcolor: "#f3c402",
-    borderRadius: "50%",
-    display: isScrolled ? "flex" : "none",
-    alignItems: "center",
-    justifyContent: "center",
-    "&:hover": {
-      bgcolor: "#f3c402",
-    },
-  };
+  const { ToTopButtonSx } = useWebHeaderStyles();
 
   return (
     <IconButton
       onClick={() => scrollTop()}
-      sx={ToTopButtonSx}
+      sx={{
+        ...ToTopButtonSx,
+        ...(!forCookieConsent &&
+          !cookieConsent && {
+            display: "none",
+          }),
+        ...(forCookieConsent && {
+          position: "absolute",
+          top: "-60px",
+        }),
+      }}
       className="fadeIn"
     >
-      <NorthIcon
-        sx={{
-          width: "25px",
-          height: "25px",
-        }}
-        className="text-[#0f2a71]"
-      />
+      <EvaIcon name="arrow-upward-outline" />
     </IconButton>
   );
 };

--- a/packages/core-library/components/ScrollTop/ScrollTop.tsx
+++ b/packages/core-library/components/ScrollTop/ScrollTop.tsx
@@ -8,7 +8,6 @@ const COOKIE_NAME = "user_cookie_consent";
 export const ScrollTop = () => {
   const { scrollTop, isScrolled } = useScroll();
   const [cookieConsent] = useCookie<string | null>(COOKIE_NAME);
-  console.log(cookieConsent);
 
   const ToTopButtonSx: SxProps = {
     position: "fixed",

--- a/packages/core-library/components/ScrollTop/ScrollTop.tsx
+++ b/packages/core-library/components/ScrollTop/ScrollTop.tsx
@@ -1,0 +1,47 @@
+import { useScroll } from "../../core";
+import NorthIcon from "@mui/icons-material/North";
+import { IconButton, SxProps } from "@mui/material";
+import { useCookie } from "../../hooks/useCookie";
+
+const COOKIE_NAME = "user_cookie_consent";
+
+export const ScrollTop = () => {
+  const { scrollTop, isScrolled } = useScroll();
+  const [cookieConsent] = useCookie<string | null>(COOKIE_NAME);
+  console.log(cookieConsent);
+
+  const ToTopButtonSx: SxProps = {
+    position: "fixed",
+    zIndex: 10000,
+    bottom: cookieConsent ? "50px" : "120px",
+    right: "50px",
+    height: "45px",
+    width: "45px",
+    boxShadow: "2px",
+    minWidth: "40px",
+    bgcolor: "#f3c402",
+    borderRadius: "50%",
+    display: isScrolled ? "flex" : "none",
+    alignItems: "center",
+    justifyContent: "center",
+    "&:hover": {
+      bgcolor: "#f3c402",
+    },
+  };
+
+  return (
+    <IconButton
+      onClick={() => scrollTop()}
+      sx={ToTopButtonSx}
+      className="fadeIn"
+    >
+      <NorthIcon
+        sx={{
+          width: "25px",
+          height: "25px",
+        }}
+        className="text-[#0f2a71]"
+      />
+    </IconButton>
+  );
+};

--- a/packages/core-library/components/index.ts
+++ b/packages/core-library/components/index.ts
@@ -51,7 +51,7 @@ export * from "./Badge/CustomBadge";
 export * from "./CSPHead";
 export * from "./LottieAnimation/LottieAnimation";
 export * from "./Stepper/ProgressStepper";
-export * from "./Popover/Popover"
+export * from "./Popover/Popover";
 
 export * from "./table/tableRows/category/CategoryOptionsTableRow";
 export * from "./Tabs/Tabs";
@@ -86,3 +86,4 @@ export * from "./PasswordToggleAdornment";
 export * from "./Charts/generic/Chart";
 export * from "./recaptcha/RecaptchaComponent";
 export * from "./Button/StatusButton";
+export * from "./ScrollTop/ScrollTop";

--- a/packages/core-library/hooks/index.ts
+++ b/packages/core-library/hooks/index.ts
@@ -46,3 +46,4 @@ export * from "./useSafeStripe";
 export * from "./useMixpanelTracker";
 export * from "./analytics/useAnalytics";
 export * from "./ipCountry/useCountryFromIp";
+export * from "./useWebHeaderStyles";

--- a/packages/core-library/hooks/useWebHeaderStyles.ts
+++ b/packages/core-library/hooks/useWebHeaderStyles.ts
@@ -6,8 +6,7 @@ Created by the Software Strategy & Development Division
 */
 
 import { SxProps, Theme } from "@mui/material/styles";
-import { useScroll } from "core-library";
-import { useRouter } from "next/router";
+import { useScroll, useRouter } from "core-library";
 
 export const useWebHeaderStyles = () => {
   const { isScrolled } = useScroll();
@@ -28,12 +27,12 @@ export const useWebHeaderStyles = () => {
     fontSize: "15px",
     ":disabled": {
       color: !isScrolledOrRoute ? "white" : "black",
-      textDecoration: 'underline'
+      textDecoration: "underline",
     },
     ":focus": {
       border: "none",
-      outline: "0 !important"
-    }
+      outline: "0 !important",
+    },
   };
 
   const loginButtonSx: SxProps = {
@@ -51,22 +50,22 @@ export const useWebHeaderStyles = () => {
     },
     ":disabled": {
       color: !isScrolledOrRoute ? "#071c51" : "#cca406",
-      textDecoration: 'underline'
-    }
+      textDecoration: "underline",
+    },
   };
 
   const ToTopButtonSx: SxProps = {
-    position: 'fixed',
+    position: "fixed",
     zIndex: 10000,
-    bottom: '50px',
-    right: '50px',
+    bottom: "50px",
+    right: "50px",
     height: "45px",
     width: "45px",
-    boxShadow: '2px',
+    boxShadow: "2px",
     minWidth: "40px",
     bgcolor: "#f3c402",
     borderRadius: "50%",
-    display: isScrolled ? 'flex' : 'none',
+    display: isScrolled ? "flex" : "none",
     alignItems: "center",
     justifyContent: "center",
     "&:hover": {

--- a/packages/core-library/hooks/useWebHeaderStyles.ts
+++ b/packages/core-library/hooks/useWebHeaderStyles.ts
@@ -6,7 +6,7 @@ Created by the Software Strategy & Development Division
 */
 
 import { SxProps, Theme } from "@mui/material/styles";
-import { useScroll, useRouter } from "core-library";
+import { useRouter, useScroll } from "../core";
 
 export const useWebHeaderStyles = () => {
   const { isScrolled } = useScroll();

--- a/packages/core-library/tests/components/ScrollTop/ScrollTop.test.tsx
+++ b/packages/core-library/tests/components/ScrollTop/ScrollTop.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent } from "../../common";
 import { ScrollTop } from "../../../components";
 import { useScroll } from "../../../core";
 import { useCookie } from "../../../hooks/useCookie";
@@ -9,6 +9,9 @@ jest.mock("../../../config", () => ({
 
 jest.mock("../../../core", () => ({
   useScroll: jest.fn(),
+  useRouter: jest.fn(() => ({
+    pathname: "/some-path",
+  })),
 }));
 
 jest.mock("../../../hooks/useCookie", () => ({
@@ -47,7 +50,34 @@ describe("ScrollTop Component", () => {
     expect(button).not.toBeInTheDocument();
   });
 
-  it("applies different bottom spacing based on cookie consent", () => {
+  it("applies absolute position when forCookieConsent is set to true", () => {
+    (useScroll as jest.Mock).mockReturnValue({
+      scrollTop: jest.fn(),
+      isScrolled: true,
+    });
+
+    (useCookie as jest.Mock).mockReturnValue([null]);
+
+    render(<ScrollTop forCookieConsent />);
+
+    const button = screen.getByRole("button");
+    expect(button).toHaveStyle({ position: "absolute", top: "-60px" });
+  });
+
+  it("hides the scroll button if forCookieConsent=false and useCookie is null", () => {
+    (useScroll as jest.Mock).mockReturnValue({
+      scrollTop: jest.fn(),
+      isScrolled: true,
+    });
+
+    (useCookie as jest.Mock).mockReturnValue([null]);
+
+    render(<ScrollTop />);
+    const button = screen.queryByRole("button");
+    expect(button).not.toBeInTheDocument();
+  });
+
+  it("shows scroll button if forCookieConsent=false and useCookie is not null", () => {
     (useScroll as jest.Mock).mockReturnValue({
       scrollTop: jest.fn(),
       isScrolled: true,
@@ -55,17 +85,9 @@ describe("ScrollTop Component", () => {
 
     (useCookie as jest.Mock).mockReturnValue(["accepted"]);
 
-    const { rerender } = render(<ScrollTop />);
-
-    let button = screen.getByRole("button");
-    expect(button).toHaveStyle({ bottom: "50px" });
-
-    (useCookie as jest.Mock).mockReturnValue([null]);
-
-    rerender(<ScrollTop />);
-
-    button = screen.getByRole("button");
-    expect(button).toHaveStyle({ bottom: "120px" });
+    render(<ScrollTop />);
+    const button = screen.getByRole("button");
+    expect(button).toHaveStyle({ display: "flex" });
   });
 
   it("calls scrollTop when button is clicked", () => {

--- a/packages/core-library/tests/components/ScrollTop/ScrollTop.test.tsx
+++ b/packages/core-library/tests/components/ScrollTop/ScrollTop.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ScrollTop } from "../../../components";
+import { useScroll } from "../../../core";
+import { useCookie } from "../../../hooks/useCookie";
+
+jest.mock("../../../config", () => ({
+  config: { value: jest.fn() },
+}));
+
+jest.mock("../../../core", () => ({
+  useScroll: jest.fn(),
+}));
+
+jest.mock("../../../hooks/useCookie", () => ({
+  useCookie: jest.fn(),
+}));
+
+describe("ScrollTop Component", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renders the ScrollTop button when scrolled", () => {
+    (useScroll as jest.Mock).mockReturnValue({
+      scrollTop: jest.fn(),
+      isScrolled: true,
+    });
+
+    (useCookie as jest.Mock).mockReturnValue(["accepted"]);
+
+    render(<ScrollTop />);
+
+    const button = screen.getByRole("button");
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveStyle({ display: "flex" });
+  });
+
+  it("hides the scroll top button when not scrolled", () => {
+    (useScroll as jest.Mock).mockReturnValue({
+      scrollTop: jest.fn(),
+      isScrolled: false,
+    });
+
+    render(<ScrollTop />);
+
+    const button = screen.queryByRole("button");
+    expect(button).not.toBeInTheDocument();
+  });
+
+  it("applies different bottom spacing based on cookie consent", () => {
+    (useScroll as jest.Mock).mockReturnValue({
+      scrollTop: jest.fn(),
+      isScrolled: true,
+    });
+
+    (useCookie as jest.Mock).mockReturnValue(["accepted"]);
+
+    const { rerender } = render(<ScrollTop />);
+
+    let button = screen.getByRole("button");
+    expect(button).toHaveStyle({ bottom: "50px" });
+
+    (useCookie as jest.Mock).mockReturnValue([null]);
+
+    rerender(<ScrollTop />);
+
+    button = screen.getByRole("button");
+    expect(button).toHaveStyle({ bottom: "120px" });
+  });
+
+  it("calls scrollTop when button is clicked", () => {
+    const mockScrollTop = jest.fn();
+
+    (useScroll as jest.Mock).mockReturnValue({
+      scrollTop: mockScrollTop,
+      isScrolled: true,
+    });
+
+    (useCookie as jest.Mock).mockReturnValue(["accepted"]);
+
+    render(<ScrollTop />);
+
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+    expect(mockScrollTop).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
- Made the cookie consent dialog fixed to the bottom of page.
- Scroll to top icon will adjust position if cookie consent dialog is present.

<img width="1440" alt="Screenshot 2025-01-06 at 2 49 28 PM" src="https://github.com/user-attachments/assets/28d70574-fa40-4705-a904-acbd6c0db590" />

<img width="1440" alt="Screenshot 2025-01-06 at 2 49 43 PM" src="https://github.com/user-attachments/assets/92c0a7b0-532f-4e63-8b6a-cfebbb7adf74" />

![iPhone-13-PRO-localhost](https://github.com/user-attachments/assets/897e1aa3-b175-4098-b160-e4e73835e074)

