### PR TITLE
Feature/86eqxm3x9/add access group identification such as admin decoder encoder

### DIFF
--- a/packages/core-library/components/GenericSidebar/Sidebar.tsx
+++ b/packages/core-library/components/GenericSidebar/Sidebar.tsx
@@ -204,7 +204,7 @@ export const Sidebar: React.FC<SideBarPropsType> = ({
                 setOpen={setOpen}
               />
               {open && (
-                <div style={{ padding: "12px" }}>
+                <div style={{ padding: "10px" }}>
                   <UserProfile onLogout={onLogout} />
                 </div>
               )}

--- a/packages/core-library/components/GenericSidebar/Sidebar.tsx
+++ b/packages/core-library/components/GenericSidebar/Sidebar.tsx
@@ -14,6 +14,7 @@ import { MenuItems } from "../../api/types";
 import { WebSidebarStylesType } from "../../types/web-sidebar-styles";
 import { useGetProgramList, useUniqueById } from "../../hooks";
 import { IconButton, EvaIcon } from "../../components";
+import { UserProfile } from "../UserProfile/UserProfile";
 
 interface SideBarPropsType extends Partial<WebSidebarStylesType> {
   menu: Array<MenuItems>;
@@ -192,15 +193,22 @@ export const Sidebar: React.FC<SideBarPropsType> = ({
               setOpen={setOpen}
             />
           ) : (
-            <RenderMenuItems
-              menu={updatedMenu.filter((navigation) => !navigation.hide)}
-              pathname={pathname}
-              isAuthenticated={isAuthenticated}
-              listStyles={listStyles}
-              isDrawerOpen={open}
-              onNavigate={handleCloseSidebar}
-              setOpen={setOpen}
-            />
+            <>
+              <RenderMenuItems
+                menu={updatedMenu.filter((navigation) => !navigation.hide)}
+                pathname={pathname}
+                isAuthenticated={isAuthenticated}
+                listStyles={listStyles}
+                isDrawerOpen={open}
+                onNavigate={handleCloseSidebar}
+                setOpen={setOpen}
+              />
+              {open && (
+                <div style={{ padding: "12px" }}>
+                  <UserProfile onLogout={onLogout} />
+                </div>
+              )}
+            </>
           )}
         </div>
       </List>

--- a/packages/core-library/components/UserProfile/UserProfile.tsx
+++ b/packages/core-library/components/UserProfile/UserProfile.tsx
@@ -1,0 +1,99 @@
+import { useAccessControl } from "../../hooks/useAccessControl";
+import { getRoleName } from "../../core/utils/permission";
+import {
+  Box,
+  Typography,
+  Avatar,
+  IconButton,
+  Popover,
+  MenuItem,
+} from "@mui/material";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
+import { useState } from "react";
+interface Props {
+  userName?: string;
+  email?: string;
+  role?: string;
+  onLogout?: () => void;
+}
+
+export const UserProfile: React.FC<Props> = ({ onLogout }) => {
+  const { accessLevel } = useAccessControl();
+  const roleName = getRoleName(accessLevel ?? -1);
+
+  const userName = "John Doe"; // Replace with actual user name
+
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
+  const id = open ? "simple-popover" : undefined;
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 2,
+        padding: 4,
+        border: "1px solid #ddd",
+        borderRadius: "8px",
+        maxWidth: "600px",
+        margin: "0 auto",
+      }}
+    >
+      <Avatar sx={{ width: 40, height: 40 }} /> {/* Smaller Avatar */}
+      <Box sx={{ display: "flex", flexDirection: "column" }}>
+        <Typography
+          variant="h6"
+          sx={{
+            fontWeight: 600,
+            fontSize: "1rem",
+            whiteSpace: "nowrap",
+            fontFamily: "PT Sans",
+          }}
+        >
+          {userName}
+        </Typography>
+        <Typography
+          variant="body2"
+          sx={{ fontSize: "0.8rem", fontFamily: "PT Sans" }}
+        >
+          {roleName || "No role assigned"}
+        </Typography>
+      </Box>
+      <IconButton
+        size="small"
+        sx={{ marginLeft: "auto" }}
+        onClick={handleClick}
+      >
+        <MoreVertIcon />
+      </IconButton>
+      <Popover
+        id={id}
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: "bottom",
+          horizontal: "left",
+        }}
+        transformOrigin={{
+          vertical: "top",
+          horizontal: "left",
+        }}
+      >
+        <MenuItem onClick={handleClose}>Edit Profile</MenuItem>
+        <MenuItem onClick={handleClose}>Log Out</MenuItem>
+      </Popover>
+    </Box>
+  );
+};

--- a/packages/core-library/core/utils/permission.ts
+++ b/packages/core-library/core/utils/permission.ts
@@ -20,6 +20,19 @@ export const accessControl = {
   [AccessLevels.ENCODER]: ["ChooseProductsConfigurations"],
 };
 
+export const getRoleName = (accessLevel: number): string => {
+  switch (accessLevel) {
+    case AccessLevels.DEVELOPER:
+      return "[Developer]";
+    case AccessLevels.ADMIN:
+      return "[Admin]";
+    case AccessLevels.ENCODER:
+      return "[Encoder]";
+    default:
+      return "[Unknown Role]";
+  }
+};
+
 export const canAccess = (accessLevel: number, component: string): boolean => {
   return accessControl[accessLevel]?.includes(component);
 };


### PR DESCRIPTION
I created a component that shows a username (not a real username) and its group identification. It has a vertical dot icon that, when clicked, displays
![Skjermbilde 2025-01-15 101024](https://github.com/user-attachments/assets/19b9802e-cc2f-4cfd-a52e-6fd8fc567ad0)
![Skjermbilde 2025-01-15 100822](https://github.com/user-attachments/assets/30f8072b-d9ef-4141-91e8-78ce864f2307)
![Skjermbilde 2025-01-15 100808](https://github.com/user-attachments/assets/fb65eb49-89d8-4816-9206-6300267c6578)
 a popup to edit the profile or to log out.
