### PR TITLE
@86erycwpr #fix medcards uploading

### DIFF
--- a/packages/core-library/system/app/internal/blocks/Hub/ProgramManagement/program-section-management/blocks/edit-item/EditDocument/EditDocumentField.tsx
+++ b/packages/core-library/system/app/internal/blocks/Hub/ProgramManagement/program-section-management/blocks/edit-item/EditDocument/EditDocumentField.tsx
@@ -91,7 +91,14 @@ export const EditDocumentField: React.FC<EditDocumentFieldProps> = ({
             <Typography sx={{ color: "#3B0086", mb: 2 }}>Link*:</Typography>
             <Box sx={{ display: "flex", alignItems: "left", lineHeight: 0 }}>
               <FileUploadField
-                acceptTypes={["pdf"]}
+                acceptTypes={[
+                  section === "document" ? "pdf" : "zip",
+                  "x-zip-compressed",
+                  "x-rar-compressed",
+                  "x-7z-compressed",
+                  "x-tar",
+                  "gzip",
+                ]}
                 triggerLabel={linkValue || "Upload Document"}
                 control={control}
                 name="link"


### PR DESCRIPTION
Added a condition on uploading:
- If the section type is "Document," allow only PDF files.
- If the section type is "Med Cards," allow ZIP, RAR, and other archive files.